### PR TITLE
Chore/#1 프로젝트 기본 환경 구축

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+## 🔥 Related Issue
+
+close: #
+
+## 📝 Description
+
+
+## ⭐️ Review

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,3 +6,5 @@ close: #
 
 
 ## ⭐️ Review
+
+

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.1.5'
 	id 'io.spring.dependency-management' version '1.1.3'
+	id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 
 group = 'com.wanted'
@@ -12,6 +13,7 @@ java {
 }
 
 configurations {
+	asciidoctorExt // html 자동 변경 사용 설정
 	compileOnly {
 		extendsFrom annotationProcessor
 	}
@@ -21,21 +23,64 @@ repositories {
 	mavenCentral()
 }
 
+ext {
+	set('snippetsDir', file("build/generated-snippets"))
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	//p6spy 설치 (3.x는 1.9.0버전 사용해야함)
 	implementation "com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.5.6"
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+	// .adocs를 html로 자동 변화
+	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'com.h2database:h2'
 }
 
 tasks.named('test') {
+	outputs.dir snippetsDir
 	useJUnitPlatform()
+}
+
+tasks.named('asciidoctor') {
+	inputs.dir snippetsDir
+	dependsOn test
+	configurations 'asciidoctorExt' // html 자동 변경 사용
+	baseDirFollowsSourceFile() // .adoc 파일에서 다른.adoc 파일을 include하여 사용할 때 경로를 동일하게 baseDir로 설정
+}
+
+asciidoctor.doFirst {
+	delete file('src/main/resources/static/docs') //실행 전 이전 html 삭제
+}
+
+// build/docs/asciidoc 에 생성된 html 문서를 src/main/resources/static/docs 에 복사해온다.
+task createDocument(type: Copy) {
+	dependsOn asciidoctor // asciidoctor 후 실행
+
+	from file("build/docs/asciidoc")
+	into file("src/main/resources/static")
+}
+
+//jar의 static/docs에 문서 복사
+bootJar {
+	dependsOn createDocument
+
+	from("${asciidoctor.outputDir}") {
+		into 'static/docs'
+	}
+}
+
+//빌드전 createDocument 실행
+build {
+	dependsOn createDocument
 }

--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,11 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
 	compileOnly 'org.projectlombok:lombok'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	//p6spy 설치 (3.x는 1.9.0버전 사용해야함)
+	implementation "com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.5.6"
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,8 @@
+= 02_02_geoRecommendEats API 명세
+:doctype: book
+:icons: front
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:seclinks:
+:docinfo: shared-head

--- a/src/main/java/com/wanted/GeoRecommendEatsApplication.java
+++ b/src/main/java/com/wanted/GeoRecommendEatsApplication.java
@@ -1,4 +1,4 @@
-package com.wanted._geoRecommendEats;
+package com.wanted;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/src/main/java/com/wanted/global/config/entity/BaseTimeEntity.java
+++ b/src/main/java/com/wanted/global/config/entity/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package com.wanted.global.config.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+  @CreatedDate
+  @Column(name = "createdAt")
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(name = "updatedAt")
+  private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/wanted/global/config/error/BusinessException.java
+++ b/src/main/java/com/wanted/global/config/error/BusinessException.java
@@ -1,0 +1,35 @@
+package com.wanted.global.config.error;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 로직에서 예외를 발생시킬 때 사용하는 언체크 예외
+ */
+@Getter
+public class BusinessException extends RuntimeException {
+
+  //오류 발생 부분의 값. 명확하게 없으면 Null.
+  private final String invalidValue;
+  //오류 필드명.
+  private final String fieldName;
+  //오류 상태 코드.
+  private final HttpStatus httpStatus;
+  //오류 메시지
+  private final String message;
+
+  /**
+   * 비지니스 에러를 ErroCode Enum으로 생성
+   *
+   * @param invalidValue 오류 발생 부분의 값
+   * @param fieldName    오류 필드 명
+   * @param errorCode    오류 상태코드와 메시지가 담긴 Enum
+   */
+  public BusinessException(Object invalidValue, String fieldName, ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.invalidValue = invalidValue != null ? invalidValue.toString() : null;
+    this.fieldName = fieldName;
+    this.httpStatus = errorCode.getHttpStatus();
+    this.message = errorCode.getMessage();
+  }
+}

--- a/src/main/java/com/wanted/global/config/error/ErrorCode.java
+++ b/src/main/java/com/wanted/global/config/error/ErrorCode.java
@@ -1,0 +1,23 @@
+package com.wanted.global.config.error;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 오류 메시지와 상태를 쉽게 추가하기 위한 Enum
+ */
+@Getter
+public enum ErrorCode {
+  ;
+
+  //오류 메시지
+  private final String message;
+  //오류 상태코드
+  private final HttpStatus httpStatus;
+
+  ErrorCode(String message, HttpStatus httpStatus) {
+    this.message = message;
+    this.httpStatus = httpStatus;
+  }
+
+}

--- a/src/main/java/com/wanted/global/config/error/ExceptionAdvice.java
+++ b/src/main/java/com/wanted/global/config/error/ExceptionAdvice.java
@@ -1,0 +1,72 @@
+package com.wanted.global.config.error;
+
+import com.wanted.global.format.response.ApiResponse;
+import java.util.stream.Collectors;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * 전역 예외 처리
+ */
+@RestControllerAdvice
+public class ExceptionAdvice {
+
+  /**
+   * BindException 오류가 발생할 때, Response 처리.
+   *
+   * @param e BindException
+   * @return Response 내용
+   */
+  @ExceptionHandler(BindException.class)
+  public ResponseEntity<ApiResponse> bindException(BindException e) {
+    String errorMessage = getErrorMessage(e);
+
+    return ResponseEntity.badRequest()
+        .body(ApiResponse.toErrorForm(errorMessage));
+  }
+
+  /**
+   * BusinessException 오류가 발생할 때, Response 처리.
+   *
+   * @param e BusinessException
+   * @return Response 내용
+   */
+  @ExceptionHandler(BusinessException.class)
+  public ResponseEntity<ApiResponse> businessException(BusinessException e) {
+    String errorMessage = getErrorMessage(e.getInvalidValue(), e.getFieldName(), e.getMessage());
+
+    return ResponseEntity.status(e.getHttpStatus())
+        .body(ApiResponse.toErrorForm(errorMessage));
+  }
+
+  /**
+   * BindingException의 bindingResult 분석 후, 오류 메시지 생성
+   *
+   * @param e BindException
+   * @return 포멧팅된 오류 메시지
+   */
+  private static String getErrorMessage(BindException e) {
+    BindingResult bindingResult = e.getBindingResult();
+
+    return bindingResult.getFieldErrors().stream()
+        .map(fieldError ->
+            getErrorMessage(
+                (String) fieldError.getRejectedValue(),
+                fieldError.getField(),
+                fieldError.getDefaultMessage()
+            )
+        )
+        .collect(Collectors.joining(", "));
+  }
+
+  /**
+   * 메시지 포멧팅
+   */
+  private static String getErrorMessage(String invalidValue, String errorField,
+      String errorMessage) {
+    return String.format("[%s] %s: %s", invalidValue, errorField, errorMessage);
+  }
+}

--- a/src/main/java/com/wanted/global/config/p6spy/P6SpyFormatter.java
+++ b/src/main/java/com/wanted/global/config/p6spy/P6SpyFormatter.java
@@ -1,0 +1,42 @@
+package com.wanted.global.config.p6spy;
+
+import com.p6spy.engine.logging.Category;
+import com.p6spy.engine.spy.P6SpyOptions;
+import com.p6spy.engine.spy.appender.MessageFormattingStrategy;
+import jakarta.annotation.PostConstruct;
+import java.util.Locale;
+import org.hibernate.engine.jdbc.internal.FormatStyle;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * p6Spy 설정 : 쿼리 로그의 가독성 높임
+ */
+@Configuration
+public class P6SpyFormatter implements MessageFormattingStrategy {
+
+  @PostConstruct
+  public void setLogMessageFormat() {
+    P6SpyOptions.getActiveInstance().setLogMessageFormat(this.getClass().getName());
+  }
+
+  @Override
+  public String formatMessage(int connectionId, String now, long elapsed, String category,
+      String prepared, String sql, String url) {
+    sql = formatSql(category, sql);
+    return String.format("[%s] | %d ms | %s", category, elapsed, formatSql(category, sql));
+  }
+
+  private String formatSql(String category, String sql) {
+    if (sql != null && !sql.trim().isEmpty() && Category.STATEMENT.getName().equals(category)) {
+      String trimmedSQL = sql.trim().toLowerCase(Locale.ROOT);
+      if (trimmedSQL.startsWith("create") || trimmedSQL.startsWith("alter")
+          || trimmedSQL.startsWith("comment")) {
+        sql = FormatStyle.DDL.getFormatter().format(sql);
+      } else {
+        sql = FormatStyle.BASIC.getFormatter().format(sql);
+      }
+      return sql;
+    }
+    return sql;
+  }
+}

--- a/src/main/java/com/wanted/global/format/response/ApiResponse.java
+++ b/src/main/java/com/wanted/global/format/response/ApiResponse.java
@@ -1,0 +1,53 @@
+package com.wanted.global.format.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Response JSON 포맷팅 형식
+ */
+@Getter
+@AllArgsConstructor
+public class ApiResponse {
+
+  private static final String STATUS_SUCCESS = "success";
+  private static final String STATUS_FAIL = "fail";
+  private static final String STATUS_ERROR = "error";
+
+  // 상태 (성공,실패,에러)
+  private String status;
+  // 실패/에러 메시지 (성공일시 null)
+  private String message;
+  // 데이터 (실패/에러일 때 null)
+  private Object data;
+
+  /**
+   * 성공했을 때, 반환하는 APIResponse
+   *
+   * @param data 데이터 내용
+   * @return 성공 APIResponse
+   */
+  public static ApiResponse toSuccessForm(Object data) {
+    return new ApiResponse(STATUS_SUCCESS, null, data);
+  }
+
+  /**
+   * 실패했을 때, 반환하는 APIResponse
+   *
+   * @param message 실패 메시지
+   * @return 실패 APIResponse
+   */
+  public static ApiResponse toFailForm(String message) {
+    return new ApiResponse(STATUS_FAIL, message, null);
+  }
+
+  /**
+   * 예외처리가 됐을 때, 반환하는 APIResponse
+   *
+   * @param message 에러 메시지
+   * @return 에러 APIResponse
+   */
+  public static ApiResponse toErrorForm(String message) {
+    return new ApiResponse(STATUS_ERROR, message, null);
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,19 @@
+server:
+  port: 8080
+  servlet:
+    context-path: /
+    encoding:
+      charset: utf-8
+    session:
+      timeout: 60
 
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/02_geoRecommendEats?allowPublicKeyRetrieval=true&useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: root
+    password: root
+
+  jpa:
+    hibernate:
+      ddl-auto: create

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,3 +17,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create
+
+#p6spy
+decorator:
+  datasource:
+    p6spy:
+      enable-logging: true

--- a/src/test/java/com/wanted/GeoRecommendEatsApplicationTests.java
+++ b/src/test/java/com/wanted/GeoRecommendEatsApplicationTests.java
@@ -1,4 +1,4 @@
-package com.wanted._geoRecommendEats;
+package com.wanted;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/src/test/java/com/wanted/config/restdocs/AbstractRestDocsTests.java
+++ b/src/test/java/com/wanted/config/restdocs/AbstractRestDocsTests.java
@@ -15,6 +15,9 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
+/**
+ * mockMvc를 사용할 때, 자동으로 rest docs 작성하게 한다.
+ */
 @Import(RestDocsConfiguration.class)
 @ExtendWith(RestDocumentationExtension.class)
 public abstract class AbstractRestDocsTests {

--- a/src/test/java/com/wanted/config/restdocs/AbstractRestDocsTests.java
+++ b/src/test/java/com/wanted/config/restdocs/AbstractRestDocsTests.java
@@ -1,0 +1,39 @@
+package com.wanted.config.restdocs;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+@Import(RestDocsConfiguration.class)
+@ExtendWith(RestDocumentationExtension.class)
+public abstract class AbstractRestDocsTests {
+
+  @Autowired
+  protected RestDocumentationResultHandler restDocs;
+
+  @Autowired
+  protected MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp(
+      final WebApplicationContext context,
+      final RestDocumentationContextProvider restDocumentation) {
+    this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+        .apply(documentationConfiguration(restDocumentation))
+        .alwaysDo(MockMvcResultHandlers.print())
+        .alwaysDo(restDocs)
+        .addFilters(new CharacterEncodingFilter("UTF-8", true))
+        .build();
+  }
+}

--- a/src/test/java/com/wanted/config/restdocs/RestDocsConfiguration.java
+++ b/src/test/java/com/wanted/config/restdocs/RestDocsConfiguration.java
@@ -1,0 +1,23 @@
+package com.wanted.config.restdocs;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.operation.preprocess.Preprocessors;
+
+/**
+ * rest docs의 가독성을 높인다.
+ */
+@TestConfiguration
+public class RestDocsConfiguration {
+
+  @Bean
+  public RestDocumentationResultHandler write() {
+    return MockMvcRestDocumentation.document(
+        "{class-name}/{method-name}", // identifier
+        Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+        Preprocessors.preprocessResponse(Preprocessors.prettyPrint())
+    );
+  }
+}


### PR DESCRIPTION
## 🔥 Related Issue

close: #1

## 📝 Description

- 사용할 포트를 8080으로 설정 하였고, DB 스키마 명은 `02_geoRecommendEats`입니다. 

- `P6Spy`로 JAP 실제 쿼리 로그를 보기좋게 설정하였습니다.
  - 추후 배포때, 로그는 `디버그`일 때만 보이도록 합니다.

- 컨트롤러 계층 테스트 때, 추상화 클래스인 `AbstractRestDocsTests`를 상속받아 `mockMvc`를 사용해야 Rest Docs가 적용됩니다.

- response 할 `Json` 형식을 `ApiResponse`로 정하였습니다. 
  - 추후 static 생성자를 사용하여, `successForm`, `failForm`, `errorForm`로 변환시킵니다.

- `BaseTimeEntity` 생성했습니다.


## ⭐️ Review
설정단계에서 혹시 빠뜨린 부분있으면 pr 부탁드립니다. 
milestone, project roadmap도 빠르게 적용하겠습니다 ~!

