### PR TITLE
Feature/#6 user관련 entity 및 dao 생성

### DIFF
--- a/src/main/java/com/wanted/domain/user/dao/UserRepository.java
+++ b/src/main/java/com/wanted/domain/user/dao/UserRepository.java
@@ -1,0 +1,8 @@
+package com.wanted.domain.user.dao;
+
+import com.wanted.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<Long, User> {
+
+}

--- a/src/main/java/com/wanted/domain/user/dao/location/UserLocationRepository.java
+++ b/src/main/java/com/wanted/domain/user/dao/location/UserLocationRepository.java
@@ -1,0 +1,8 @@
+package com.wanted.domain.user.dao.location;
+
+import com.wanted.domain.user.entity.location.UserLocation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserLocationRepository extends JpaRepository<Long, UserLocation> {
+
+}

--- a/src/main/java/com/wanted/domain/user/entity/User.java
+++ b/src/main/java/com/wanted/domain/user/entity/User.java
@@ -31,6 +31,7 @@ public class User extends BaseTimeEntity {
   // 유저의 아이디
   @Id
   @GeneratedValue(strategy = IDENTITY)
+  @Column(name = "user_id", nullable = false)
   private Long id;
 
   // 유저 위치 (1:1)

--- a/src/main/java/com/wanted/domain/user/entity/User.java
+++ b/src/main/java/com/wanted/domain/user/entity/User.java
@@ -1,0 +1,48 @@
+package com.wanted.domain.user.entity;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import com.wanted.domain.user.entity.location.UserLocation;
+import com.wanted.global.config.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 유저의 엔티티
+ */
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "user")
+public class User extends BaseTimeEntity {
+
+  public static final int MAX_ACCOUNT_LENGTH = 20;
+  public static final int MAX_PASSWORD_LENGTH = 256;
+
+  // 유저의 아이디
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  private Long id;
+
+  // 유저 위치 (1:1)
+  @OneToOne(fetch = LAZY)
+  @JoinColumn(name = "user_location_id", nullable = true)
+  private UserLocation userLocation;
+
+  // 계정 명
+  @Column(name = "account", nullable = false, length = MAX_ACCOUNT_LENGTH)
+  private String account;
+
+  // 비밀번호
+  @Column(name = "password", nullable = false, length = MAX_PASSWORD_LENGTH)
+  private String password;
+}

--- a/src/main/java/com/wanted/domain/user/entity/location/UserLocation.java
+++ b/src/main/java/com/wanted/domain/user/entity/location/UserLocation.java
@@ -1,0 +1,36 @@
+package com.wanted.domain.user.entity.location;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import com.wanted.global.config.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 유저의 위치 엔티티
+ */
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "user_location")
+public class UserLocation extends BaseTimeEntity {
+
+  // 유저 위치의 아이디
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  private Long id;
+
+  // 위도
+  @Column(name = "lat", nullable = false)
+  private Double lat;
+
+  // 경도
+  @Column(name = "logt", nullable = false)
+  private Double logt;
+}

--- a/src/main/java/com/wanted/domain/user/entity/location/UserLocation.java
+++ b/src/main/java/com/wanted/domain/user/entity/location/UserLocation.java
@@ -24,6 +24,7 @@ public class UserLocation extends BaseTimeEntity {
   // 유저 위치의 아이디
   @Id
   @GeneratedValue(strategy = IDENTITY)
+  @Column(name = "user_location_id", nullable = false)
   private Long id;
 
   // 위도

--- a/src/main/java/com/wanted/global/config/jpa/JpaConfig.java
+++ b/src/main/java/com/wanted/global/config/jpa/JpaConfig.java
@@ -1,0 +1,10 @@
+package com.wanted.global.config.jpa;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaConfig {
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,9 @@ spring:
     url: jdbc:mysql://localhost:3306/02_geoRecommendEats?allowPublicKeyRetrieval=true&useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: root
     password: root
+  jpa:
+    hibernate:
+      ddl-auto: update
 
 #p6spy
 decorator:


### PR DESCRIPTION
## 🔥 Related Issue

close: #6 

## 📝 Description
user관련 entity 및 dao를 생성하였습니다.


## ⭐️ Review
`user`와 `user_location`은 1:1 관계이고, user를 외래키를 두었습니다.
 user_location은 null 값일 될 수 있다고 판단되어 좀 애매한 것 같습니다.
```text
1. 주테이블(MEMBER)에 외래키 

주 객체가 대상 객체를 참조하는 것처럼 주 테이블에 외래 키를 두고 대상 테이블을 참조한다. 

외래키를 객체 참조와 비슷하게 사용할 수 있다는 장점이 있다.

주테이블이 외래키를 가져, 주 테이블만 확인해도 대상 테이블과 연관관계가 있는지 알 수 있다.

단점:값이 없으면 외래키에 null 허용해야한다.

 

2. 대상 테이블(LOCKER)에 외래키 

테이블 관계를 일대일에서 일대다로 변경할 때 테이블 구조를 그대로 유지할 수 있다.

단점:프록시 기능의 한계로 지연로딩을 설정해도 항상 즉시 로딩된다.
```
