### PR TITLE
Feature/#19 시구군 전체 데이터 조회

### DIFF
--- a/src/main/java/com/wanted/domain/restaurant/api/location/LocationController.java
+++ b/src/main/java/com/wanted/domain/restaurant/api/location/LocationController.java
@@ -1,0 +1,35 @@
+package com.wanted.domain.restaurant.api.location;
+
+import com.wanted.domain.restaurant.application.location.LocationService;
+import com.wanted.domain.restaurant.dto.location.response.CsvResponseDto;
+import com.wanted.global.util.format.response.ApiResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/location")
+public class LocationController {
+
+    private final LocationService locationService;
+
+    /**
+     * 전체 시구군 조회
+     *
+     * @return 200 , 전체 시구군 정보(dosi(도시), sigungu(시군구) lat(y축) ,lon(x축))
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse> getAllLocations(){
+        List<CsvResponseDto> locations = locationService.getAllLocations();
+
+        ApiResponse apiResponse = ApiResponse.toSuccessForm(locations);
+
+        return ResponseEntity.ok(apiResponse);
+    }
+
+
+}

--- a/src/main/java/com/wanted/domain/restaurant/application/location/LocationService.java
+++ b/src/main/java/com/wanted/domain/restaurant/application/location/LocationService.java
@@ -1,0 +1,25 @@
+package com.wanted.domain.restaurant.application.location;
+
+import com.wanted.domain.restaurant.dto.location.response.CsvResponseDto;
+import com.wanted.global.util.csv.CsvSaveDto;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LocationService {
+
+    private final CsvSaveDto csvSaveDto;
+
+    /**
+     * 전체 시구군 조회
+     *
+     * @return CsvResponseDto 리스트 , fields: dosi(도시), sigungu(시군구) lat(y축) ,lon(x축)
+     */
+    public List<CsvResponseDto> getAllLocations(){
+        return csvSaveDto.getAllDosiAndSigungu();
+    }
+
+}

--- a/src/main/java/com/wanted/global/util/csv/CsvSaveDto.java
+++ b/src/main/java/com/wanted/global/util/csv/CsvSaveDto.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.Getter;
 import org.springframework.stereotype.Component;
 
@@ -49,5 +50,19 @@ public class CsvSaveDto {
         .filter(dto -> sigungu.equals(dto.getSiGunGu()))
         .findFirst()
         .orElseThrow();
+  }
+
+  /**
+   * 전체 시군구를 반환한다.
+   *
+   * @return CsvResponseDto  -> fields:  lat ,lon sigungu,dosi
+   */
+  public List<CsvResponseDto> getAllDosiAndSigungu(){
+    List<CsvResponseDto> allResponseDtoList =
+        csvParserCollection.values().stream()
+            .flatMap(List::stream)
+            .collect(Collectors.toList());
+
+    return allResponseDtoList;
   }
 }

--- a/src/test/java/com/wanted/global/utils/csv/CsvTest.java
+++ b/src/test/java/com/wanted/global/utils/csv/CsvTest.java
@@ -1,5 +1,8 @@
 package com.wanted.global.utils.csv;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.wanted.domain.restaurant.dto.location.response.CsvResponseDto;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -9,8 +12,10 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvFileSource;
@@ -66,7 +71,7 @@ public class CsvTest {
   @Test
   void linesData를_Dto_변환이후_Map_넣고_강원에_데이터가_18개인지확인() {
     int MAX_LEN_GANGWON = 18;
-    Assertions.assertEquals(MAX_LEN_GANGWON, saveLines.get("강원").size());
+    assertEquals(MAX_LEN_GANGWON, saveLines.get("강원").size());
   }
 
   @Test
@@ -76,6 +81,22 @@ public class CsvTest {
         .filter(dto -> "홍천군".equals(dto.getSiGunGu()))
         .toList();
     System.out.println(hongcheon.get(0).getDoSi());
-    Assertions.assertEquals(hongcheon.get(0).getSiGunGu(), "홍천군");
+    assertEquals(hongcheon.get(0).getSiGunGu(), "홍천군");
+  }
+
+  @Test
+  void 전체_시구군을_조회한다(){
+    List<CsvResponseDto> allResponseDtoList =
+        saveLines.values().stream()
+            .flatMap(List::stream)
+            .collect(Collectors.toList());
+
+    int total = saveLines.values().stream()
+                .mapToInt(List::size)
+                .sum();
+
+    assertEquals(total, allResponseDtoList.size());
+
+    allResponseDtoList.forEach(dto -> System.out.println(dto.toString()));
   }
 }


### PR DESCRIPTION
## 🔥 Related Issue

close: #19 

## 📝 Description

1. 시구군 전체 데이터 조회 엔드포인트 구현했습니다.
- controller, service 추가했습니다.
- service는 db 조회가 아니라 테스트를 구현하지 않았습니다.
- controller 테스트는 csv파일 읽어오는 부분에서 헤매서 진행중에 있습니다. (postman으로 일단 확인했습니다ㅠ)
![image](https://github.com/wanted-preonboarding-team-m/02_geoRecommendEats/assets/57309311/46f53c57-66b1-48ba-9406-76748aa3b377)


2. 기존 CsvSaveDto class에 전체 조회 기능을 추가했습니다.
- 기존에 Map<String, List<CsvResponseDto>> 으로 저장해놓은걸 그냥 value값만 따로 빼서 저장하는 형식으로 구현했습니다.
```
  /**
   * 전체 시군구를 반환한다.
   *
   * @return CsvResponseDto  -> fields:  lat ,lon sigungu,dosi
   */
  public List<CsvResponseDto> getAllDosiAndSigungu(){
    List<CsvResponseDto> allResponseDtoList =
        csvParserCollection.values().stream()
            .flatMap(List::stream)
            .collect(Collectors.toList());

    return allResponseDtoList;
  }
```
- CsvTest 에 로직 테스트를 진행했습니다.

## ⭐️ Review

전체 조회 테스트를 하고 싶은데 csv 파일 읽어오는 부분에서 막혀서 고민중에 있습니다^_ㅠ
또 전체 조회하는 부분이 제가 정훈님 코드를 분석하고 여기다 하면 좋겠다! 라고 해서 CsvSaveDto에 구현했습니다. 아니라면 피드백 부탁드립니닷






