### PR TITLE
Feature/#28 사용자 위치 업데이트 및 정보 반환 기능 구현

### DIFF
--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -60,3 +60,35 @@ Response
 
 include::{snippets}/login/올바른_토큰일_경우_로그아웃에_성공한다/http-response.adoc[]
 
+== 사용자 정보 조회
+
+Request
+
+include::{snippets}/read-member/토큰이_올바를_때_사용자_정보_반환_기능이_정상적으로_작동한다/http-request.adoc[]
+
+Response
+
+- 200
+
+include::{snippets}/read-member/토큰이_올바를_때_사용자_정보_반환_기능이_정상적으로_작동한다/http-response.adoc[]
+
+- 401
+
+include::{snippets}/read-member/토큰이_올바르지_않을_때_사용자_정보_반환_기능이_예외가_발생한다/http-response.adoc[]
+
+== 사용자 위치 정보 수정
+
+Request
+
+include::{snippets}/update-member/접근_권한이_있을_때_사용자_위치_정보_수정이_정상적으로_작동된다/http-request.adoc[]
+
+Response
+
+- 201
+
+include::{snippets}/update-member/접근_권한이_있을_때_사용자_위치_정보_수정이_정상적으로_작동된다/http-response.adoc[]
+
+
+- 403
+
+include::{snippets}/update-member/접근_권한이_없을_때_사용자_위치_정보_수정이_예외가_발생한다/http-response.adoc[]

--- a/src/main/java/com/wanted/domain/member/api/MemberController.java
+++ b/src/main/java/com/wanted/domain/member/api/MemberController.java
@@ -1,12 +1,20 @@
 package com.wanted.domain.member.api;
 
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
 import com.wanted.domain.member.application.MemberService;
+import com.wanted.domain.member.dto.request.MemberLocationUpdateReqDto;
 import com.wanted.domain.member.dto.response.MemberInfoResDto;
 import com.wanted.global.util.format.response.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -30,5 +38,25 @@ public class MemberController {
     MemberInfoResDto resDto = memberService.readMemberInfo(memberId);
 
     return ResponseEntity.ok(ApiResponse.toSuccessForm(resDto));
+  }
+
+  /**
+   * 유저 위치 업데이트
+   *
+   * @param token    JWT 토큰
+   * @param memberId 회원 ID
+   * @param reqDto   유저 위치 정보
+   * @return 업데이트된 유저 위치 ID
+   */
+  @PutMapping("/location/{memberId}")
+  public ResponseEntity<ApiResponse> updateUserLocation(
+      @RequestHeader(AUTHORIZATION) String token,
+      @PathVariable("memberId") Long memberId,
+      @RequestBody @Valid MemberLocationUpdateReqDto reqDto
+  ) {
+    Long locationId = memberService.updateLocation(token, memberId, reqDto);
+
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(ApiResponse.toSuccessForm(locationId));
   }
 }

--- a/src/main/java/com/wanted/domain/member/api/MemberController.java
+++ b/src/main/java/com/wanted/domain/member/api/MemberController.java
@@ -1,0 +1,34 @@
+package com.wanted.domain.member.api;
+
+import com.wanted.domain.member.application.MemberService;
+import com.wanted.domain.member.dto.response.MemberInfoResDto;
+import com.wanted.global.util.format.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/member")
+@RequiredArgsConstructor
+public class MemberController {
+
+  private final MemberService memberService;
+
+  /**
+   * 유저에 관한 정보 읽기
+   *
+   * @param memberId 유저 아이디
+   * @return 비밀번호를 제외한 유저의 정보
+   */
+  @GetMapping("/{memberId}")
+  public ResponseEntity<ApiResponse> readUserInfo(
+      @PathVariable("memberId") Long memberId
+  ) {
+    MemberInfoResDto resDto = memberService.readMemberInfo(memberId);
+
+    return ResponseEntity.ok(ApiResponse.toSuccessForm(resDto));
+  }
+}

--- a/src/main/java/com/wanted/domain/member/application/MemberService.java
+++ b/src/main/java/com/wanted/domain/member/application/MemberService.java
@@ -1,8 +1,11 @@
 package com.wanted.domain.member.application;
 
 import com.wanted.domain.member.dao.MemberRepository;
+import com.wanted.domain.member.dao.location.MemberLocationRepository;
+import com.wanted.domain.member.dto.request.MemberLocationUpdateReqDto;
 import com.wanted.domain.member.dto.response.MemberInfoResDto;
 import com.wanted.domain.member.entity.Member;
+import com.wanted.domain.member.entity.location.MemberLocation;
 import com.wanted.global.config.security.TokenProvider;
 import com.wanted.global.error.BusinessException;
 import com.wanted.global.error.ErrorCode;
@@ -16,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
   private final MemberRepository memberRepository;
+  private final MemberLocationRepository memberLocationRepository;
   private final TokenProvider tokenProvider;
 
   /**
@@ -27,11 +31,70 @@ public class MemberService {
   public MemberInfoResDto readMemberInfo(
       Long memberId
   ) {
-    Member member = memberRepository.findById(memberId).orElseThrow(
-        () -> new BusinessException(memberId, "memberId", ErrorCode.MEMBER_NOT_FOUND)
-    );
+    Member member = getMemberById(memberId);
 
     MemberInfoResDto resDto = new MemberInfoResDto(member);
     return resDto;
+  }
+
+  /**
+   * id로 회원 찾기
+   *
+   * @param memberId 회원 ID
+   * @return 찾은 회원
+   */
+  private Member getMemberById(Long memberId) {
+    Member member = memberRepository.findById(memberId).orElseThrow(
+        () -> new BusinessException(memberId, "memberId", ErrorCode.MEMBER_NOT_FOUND)
+    );
+    return member;
+  }
+
+  /**
+   * 유저 위치를 생성 또는 업데이트
+   *
+   * @param token    JWT 토큰
+   * @param memberId 회원 id
+   * @param reqDto   위치 정보 데이터
+   * @return 위치 ID
+   */
+  @Transactional
+  public Long updateLocation(
+      String token,
+      Long memberId,
+      MemberLocationUpdateReqDto reqDto
+  ) {
+    // 토큰 검증
+    checkAuth(token, memberId);
+
+    Member member = getMemberById(memberId);
+    MemberLocation memberLocation = reqDto.toEntity();
+
+    // 처음 위치를 저장 하면, 컬럼 저장.
+    if (member.getMemberLocation() == null) {
+      memberLocationRepository.save(memberLocation);
+      member.updateLocation(memberLocation);
+
+      return memberLocation.getId();
+    }
+
+    // 처음이 아니면, 업데이트.
+    member.getMemberLocation().update(memberLocation);
+    return member.getMemberLocation().getId();
+  }
+
+  /**
+   * 접근 권한이 있는지 확인
+   * 토큰의 account 명과 접근하려는 회원의 account 명이 같은지 확인
+   *
+   * @param token    JWT 토큰
+   * @param memberId 확인할 id
+   */
+  private void checkAuth(String token, Long memberId) {
+    String account = getMemberById(memberId).getAccount();
+
+    if (!tokenProvider.getAccountFromToken(token).equals(account)) {
+      throw new BusinessException(memberId, "memberId", ErrorCode.ACCESS_AUTH_ENTRY_EXCEPTION);
+    }
   }
 }

--- a/src/main/java/com/wanted/domain/member/application/MemberService.java
+++ b/src/main/java/com/wanted/domain/member/application/MemberService.java
@@ -94,7 +94,7 @@ public class MemberService {
     String account = getMemberById(memberId).getAccount();
 
     if (!tokenProvider.getAccountFromToken(token).equals(account)) {
-      throw new BusinessException(memberId, "memberId", ErrorCode.ACCESS_AUTH_ENTRY_EXCEPTION);
+      throw new BusinessException(memberId, "memberId", ErrorCode.ACCESS_DENIED_EXCEPTION);
     }
   }
 }

--- a/src/main/java/com/wanted/domain/member/application/MemberService.java
+++ b/src/main/java/com/wanted/domain/member/application/MemberService.java
@@ -1,0 +1,37 @@
+package com.wanted.domain.member.application;
+
+import com.wanted.domain.member.dao.MemberRepository;
+import com.wanted.domain.member.dto.response.MemberInfoResDto;
+import com.wanted.domain.member.entity.Member;
+import com.wanted.global.config.security.TokenProvider;
+import com.wanted.global.error.BusinessException;
+import com.wanted.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberService {
+
+  private final MemberRepository memberRepository;
+  private final TokenProvider tokenProvider;
+
+  /**
+   * 유저에 관한 정보를 줌
+   *
+   * @param memberId 유저 Id
+   * @return 유저 정보 dto
+   */
+  public MemberInfoResDto readMemberInfo(
+      Long memberId
+  ) {
+    Member member = memberRepository.findById(memberId).orElseThrow(
+        () -> new BusinessException(memberId, "memberId", ErrorCode.MEMBER_NOT_FOUND)
+    );
+
+    MemberInfoResDto resDto = new MemberInfoResDto(member);
+    return resDto;
+  }
+}

--- a/src/main/java/com/wanted/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/wanted/domain/member/dao/MemberRepository.java
@@ -3,6 +3,8 @@ package com.wanted.domain.member.dao;
 import com.wanted.domain.member.entity.Member;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
@@ -12,4 +14,17 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
    * @return Optional 회원
    */
   Optional<Member> findByAccount(String account);
+
+  /**
+   * 회원 ID로 회원 + 회원 위치 패치 조인
+   *
+   * @param memberId 회원 id
+   * @return 회원 위치를 포함한 회원
+   */
+  @Query("SELECT m "
+      + "FROM Member m "
+      + "LEFT JOIN FETCH m.memberLocation "
+      + "WHERE m.id =:memberId")
+  Optional<Member> findWithMemberLocationById(@Param("memberId") Long memberId);
+
 }

--- a/src/main/java/com/wanted/domain/member/dto/request/MemberLocationUpdateReqDto.java
+++ b/src/main/java/com/wanted/domain/member/dto/request/MemberLocationUpdateReqDto.java
@@ -1,0 +1,33 @@
+package com.wanted.domain.member.dto.request;
+
+import com.wanted.domain.member.entity.location.MemberLocation;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 유저 위치를 업데이트할 때 사용하는 데이터를 받는 dto
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberLocationUpdateReqDto {
+
+  // 위도
+  @NotNull
+  private Double lat;
+
+  // 경도
+  @NotNull
+  private Double logt;
+
+  public MemberLocation toEntity() {
+    return MemberLocation.builder()
+        .lat(this.lat)
+        .logt(this.logt)
+        .build();
+  }
+}

--- a/src/main/java/com/wanted/domain/member/dto/response/MemberInfoResDto.java
+++ b/src/main/java/com/wanted/domain/member/dto/response/MemberInfoResDto.java
@@ -1,0 +1,34 @@
+package com.wanted.domain.member.dto.response;
+
+import com.wanted.domain.member.entity.Member;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 회원의 정보 데이터를 전달하는 dto
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberInfoResDto {
+
+  // 회원 id
+  private String account;
+  // 생성 시간
+  private LocalDateTime createdAt;
+  // 수정 시간
+  private LocalDateTime updatedAt;
+  // 권한
+  private String authority;
+
+  public MemberInfoResDto(Member member) {
+    this.account = member.getAccount();
+    this.createdAt = member.getCreatedAt();
+    this.updatedAt = member.getUpdatedAt();
+    this.authority = member.getAuthority().toString();
+  }
+}

--- a/src/main/java/com/wanted/domain/member/dto/response/MemberInfoResDto.java
+++ b/src/main/java/com/wanted/domain/member/dto/response/MemberInfoResDto.java
@@ -24,11 +24,14 @@ public class MemberInfoResDto {
   private LocalDateTime updatedAt;
   // 권한
   private String authority;
+  // 위치 정보
+  private MemberLocationResDto memberLocation;
 
   public MemberInfoResDto(Member member) {
     this.account = member.getAccount();
     this.createdAt = member.getCreatedAt();
     this.updatedAt = member.getUpdatedAt();
     this.authority = member.getAuthority().toString();
+    this.memberLocation = new MemberLocationResDto(member.getMemberLocation());
   }
 }

--- a/src/main/java/com/wanted/domain/member/dto/response/MemberLocationResDto.java
+++ b/src/main/java/com/wanted/domain/member/dto/response/MemberLocationResDto.java
@@ -1,0 +1,34 @@
+package com.wanted.domain.member.dto.response;
+
+import com.wanted.domain.member.entity.location.MemberLocation;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 회원 위치 Entity의 정보를 전달하는 dto
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberLocationResDto {
+
+  // 위도
+  private Double lat;
+  // 경도
+  private Double logt;
+  // 생성 시간
+  private LocalDateTime createdAt;
+  // 수정 시간
+  private LocalDateTime updatedAt;
+
+  public MemberLocationResDto(MemberLocation memberLocation) {
+    this.lat = memberLocation.getLat();
+    this.logt = memberLocation.getLogt();
+    this.createdAt = memberLocation.getCreatedAt();
+    this.updatedAt = memberLocation.getUpdatedAt();
+  }
+}

--- a/src/main/java/com/wanted/domain/member/entity/Member.java
+++ b/src/main/java/com/wanted/domain/member/entity/Member.java
@@ -64,4 +64,13 @@ public class Member extends BaseTimeEntity {
     this.password = password;
     this.authority = authority;
   }
+
+  /**
+   * 지역 업데이트
+   *
+   * @param memberLocation 업데이트할 지역
+   */
+  public void updateLocation(MemberLocation memberLocation) {
+    this.memberLocation = memberLocation;
+  }
 }

--- a/src/main/java/com/wanted/domain/member/entity/location/MemberLocation.java
+++ b/src/main/java/com/wanted/domain/member/entity/location/MemberLocation.java
@@ -9,6 +9,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -18,6 +20,8 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@AllArgsConstructor
+@Builder
 @Table(name = "member_location")
 public class MemberLocation extends BaseTimeEntity {
 
@@ -34,4 +38,14 @@ public class MemberLocation extends BaseTimeEntity {
   // 경도
   @Column(name = "logt", nullable = false)
   private Double logt;
+
+  /**
+   * Entity 로 수정
+   *
+   * @param memberLocation Entity
+   */
+  public void update(MemberLocation memberLocation) {
+    this.lat = memberLocation.getLat();
+    this.logt = memberLocation.getLogt();
+  }
 }

--- a/src/main/java/com/wanted/global/config/security/TokenProvider.java
+++ b/src/main/java/com/wanted/global/config/security/TokenProvider.java
@@ -149,4 +149,24 @@ public class TokenProvider {
     }
     return false;
   }
+
+
+  /**
+   * 토큰에서 회원 id 찾기
+   *
+   * @param token 토큰
+   * @return 찾은 ID
+   */
+  public String getAccountFromToken(String token) {
+    if (token.startsWith("Bearer ")) {
+      token = token.substring(7);
+    }
+
+    return String.valueOf(Jwts.parserBuilder()
+        .setSigningKey(key)
+        .build()
+        .parseClaimsJws(token)
+        .getBody()
+        .getSubject());
+  }
 }

--- a/src/main/java/com/wanted/global/error/ErrorCode.java
+++ b/src/main/java/com/wanted/global/error/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
   MEMBER_ACCOUNT_DUPLICATE("중복된 아이디 입니다.", HttpStatus.BAD_REQUEST),
   MEMBER_ACCOUNT_NOT_FOUND("아이디를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
   MEMBER_PASSWORD_BAD_REQUEST("비밀번호가 틀렸습니다.", HttpStatus.BAD_REQUEST),
+  MEMBER_NOT_FOUND("존재하지 않은 회원입니다", HttpStatus.BAD_REQUEST),
 
   // Security
   ACCESS_DENIED_EXCEPTION("필요한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
@@ -30,8 +31,7 @@ public enum ErrorCode {
   MEMBER_LOGOUT("로그아웃 된 사용자입니다.", HttpStatus.BAD_REQUEST),
   REFRESH_TOKEN_BAD_REQUEST("Refresh Token 이 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
   REFRESH_TOKEN_MISMATCH("Refresh Token 이 알맞지 않습니다.", HttpStatus.BAD_REQUEST),
-  ACCESS_TOKEN_BAD_REQUEST("Access Token 이 알맞지 않습니다.", HttpStatus.BAD_REQUEST),
-  ;
+  ACCESS_TOKEN_BAD_REQUEST("Access Token 이 알맞지 않습니다.", HttpStatus.BAD_REQUEST);
 
   //오류 메시지
   private final String message;

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -459,6 +459,8 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_로그인">로그인</a></li>
 <li><a href="#_토큰_재발급">토큰 재발급</a></li>
 <li><a href="#_로그아웃">로그아웃</a></li>
+<li><a href="#_사용자_정보_조회">사용자 정보 조회</a></li>
+<li><a href="#_사용자_위치_정보_수정">사용자 위치 정보 수정</a></li>
 </ul>
 </li>
 </ul>
@@ -561,7 +563,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/auth/signup?_csrf=eZ7gKnGTexr1nqofxnBSY5TU34WIQ_EO-lerXA-HhFA8Q0w-SqzUGkP3SX_YrZJ99l1mAPbm8uS5c8cjzWGeOTawtWkOey4J HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/auth/signup HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Content-Length: 93
 Host: localhost:8080
@@ -627,7 +629,7 @@ Content-Length: 125
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/auth/login?_csrf=iEPx4yCJ75Ov5ZgnMyGrsJ2FRI70Kpt9BEcXjDMCoOTKk3MguXeU1EGxjaWC1vxBBAyf06WyaezFH_5QYiQuuQs0k9b_pEEV HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/auth/login HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Content-Length: 57
 Host: localhost:8080
@@ -696,7 +698,7 @@ Content-Length: 112
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/auth/login?_csrf=iEPx4yCJ75Ov5ZgnMyGrsJ2FRI70Kpt9BEcXjDMCoOTKk3MguXeU1EGxjaWC1vxBBAyf06WyaezFH_5QYiQuuQs0k9b_pEEV HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/auth/login HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Content-Length: 57
 Host: localhost:8080
@@ -765,7 +767,7 @@ Content-Length: 112
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/auth/logout?_csrf=FYEPbJIMiMZTogtMF9YFMmmlRBWds4NBhNrj9qnSiuaTebh4J-U9VfM5vf5-kDx1c_sxC1-TaXStgbds4eOCw8jl79L3GI5M HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/auth/logout HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Content-Length: 97
 Host: localhost:8080
@@ -795,6 +797,140 @@ Content-Length: 67
 {
   "status" : "success",
   "message" : null,
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_사용자_정보_조회">사용자 정보 조회</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Request</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/member/1 HTTP/1.1
+Authorization: JWT_TOKEN
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Response</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>200</p>
+</li>
+</ul>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+Content-Length: 317
+
+{
+  "status" : "success",
+  "message" : null,
+  "data" : {
+    "account" : "test1234",
+    "createdAt" : null,
+    "updatedAt" : null,
+    "authority" : "ROLE_USER",
+    "memberLocation" : {
+      "lat" : 1232.111,
+      "logt" : 212.1232,
+      "createdAt" : null,
+      "updatedAt" : null
+    }
+  }
+}</code></pre>
+</div>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>401</p>
+</li>
+</ul>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 401 Unauthorized
+Content-Type: application/json;charset=UTF-8
+Content-Length: 101
+
+{
+  "status" : "error",
+  "message" : "[] : 유요한 자격이 없습니다.",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_사용자_위치_정보_수정">사용자 위치 정보 수정</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Request</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /api/v1/member/location/1 HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: JWT_TOKEN
+Content-Length: 44
+Host: localhost:8080
+
+{
+  "lat" : 112.121,
+  "logt" : 121.121
+}</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Response</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>201</p>
+</li>
+</ul>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
+Content-Type: application/json;charset=UTF-8
+Content-Length: 64
+
+{
+  "status" : "success",
+  "message" : null,
+  "data" : 1
+}</code></pre>
+</div>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>403</p>
+</li>
+</ul>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 403 Forbidden
+Content-Type: application/json;charset=UTF-8
+Content-Length: 117
+
+{
+  "status" : "error",
+  "message" : "[1] memberId: 필요한 접근 권한이 없습니다.",
   "data" : null
 }</code></pre>
 </div>

--- a/src/test/java/com/wanted/config/restdocs/AbstractRestDocsTests.java
+++ b/src/test/java/com/wanted/config/restdocs/AbstractRestDocsTests.java
@@ -1,10 +1,6 @@
 package com.wanted.config.restdocs;
 
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,7 +9,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
-import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -42,9 +37,6 @@ public abstract class AbstractRestDocsTests {
         .alwaysDo(MockMvcResultHandlers.print())
         .alwaysDo(restDocs)
         .addFilters(new CharacterEncodingFilter("UTF-8", true))
-        .defaultRequest(post("/**").with(csrf()))
-        .defaultRequest(patch("/**").with(csrf()))
-        .defaultRequest(delete("/**").with(csrf()))
         .build();
   }
 }

--- a/src/test/java/com/wanted/domain/auth/api/AuthControllerTest.java
+++ b/src/test/java/com/wanted/domain/auth/api/AuthControllerTest.java
@@ -22,14 +22,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-@WebMvcTest(controllers = AuthController.class,
-    excludeFilters = {
-        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfigurer.class)})
+@WebMvcTest(controllers = AuthController.class)
 class AuthControllerTest extends AbstractRestDocsTests {
 
   private static final String AUTH_URL = "/api/v1/auth";

--- a/src/test/java/com/wanted/domain/member/MemberTestHelper.java
+++ b/src/test/java/com/wanted/domain/member/MemberTestHelper.java
@@ -2,6 +2,7 @@ package com.wanted.domain.member;
 
 import com.wanted.domain.member.entity.Authority;
 import com.wanted.domain.member.entity.Member;
+import com.wanted.domain.member.entity.location.MemberLocation;
 
 /**
  * 회원에 관한 테스트 헬퍼
@@ -22,6 +23,13 @@ public class MemberTestHelper {
         .account("test1234")
         .password("test123*")
         .authority(Authority.ROLE_USER)
+        .build();
+  }
+
+  public static MemberLocation createMemberLocation() {
+    return MemberLocation.builder()
+        .lat(1232.111)
+        .logt(212.1232)
         .build();
   }
 }

--- a/src/test/java/com/wanted/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/com/wanted/domain/member/api/MemberControllerTest.java
@@ -1,0 +1,118 @@
+package com.wanted.domain.member.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wanted.config.restdocs.AbstractRestDocsTests;
+import com.wanted.domain.member.MemberTestHelper;
+import com.wanted.domain.member.application.MemberService;
+import com.wanted.domain.member.dto.request.MemberLocationUpdateReqDto;
+import com.wanted.domain.member.dto.response.MemberInfoResDto;
+import com.wanted.domain.member.dto.response.MemberLocationResDto;
+import com.wanted.domain.member.entity.Member;
+import com.wanted.global.error.BusinessException;
+import com.wanted.global.error.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@WebMvcTest(controllers = MemberController.class)
+class MemberControllerTest extends AbstractRestDocsTests {
+
+  private static final String MEMBER_URL = "/api/v1/member";
+
+  @Autowired
+  private ObjectMapper objectMapper;
+  @MockBean
+  private MemberService memberService;
+
+  Member member = MemberTestHelper.createMemberWithId();
+
+  @Nested
+  @DisplayName("사용자 조회 관련 컨트롤러 테스트")
+  class readMember {
+
+    @Test
+    @DisplayName("토큰이 올바를 때, 사용자 정보 반환 기능이 정상적으로 작동한다.")
+    void 토큰이_올바를_때_사용자_정보_반환_기능이_정상적으로_작동한다() throws Exception {
+      MemberInfoResDto resDto =
+          MemberInfoResDto.builder()
+              .account(member.getAccount())
+              .memberLocation(new MemberLocationResDto(MemberTestHelper.createMemberLocation()))
+              .authority(member.getAuthority().toString())
+              .build();
+
+      given(memberService.readMemberInfo(1L)).willReturn(resDto);
+
+      mockMvc.perform(get(MEMBER_URL + "/1")
+              .header(HttpHeaders.AUTHORIZATION, "JWT_TOKEN"))
+          .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    @DisplayName("토큰이 올바르지 않을 때, 사용자 정보 반환 기능이 예외가 발생한다.")
+    void 토큰이_올바르지_않을_때_사용자_정보_반환_기능이_예외가_발생한다() throws Exception {
+
+      given(memberService.readMemberInfo(1L)).willThrow(
+          new BusinessException("", "", ErrorCode.ACCESS_AUTH_ENTRY_EXCEPTION)
+      );
+
+      mockMvc.perform(get(MEMBER_URL + "/1"))
+          .andExpect(MockMvcResultMatchers.status().isUnauthorized());
+    }
+  }
+
+  @Nested
+  @DisplayName("사용자 수정 관련 컨트롤러 테스트")
+  class updateMember {
+
+    @Test
+    @DisplayName("접근 권한이 있을 때, 사용자 위치 정보 수정이 정상적으로 작동된다.")
+    @WithMockUser
+    void 접근_권한이_있을_때_사용자_위치_정보_수정이_정상적으로_작동된다() throws Exception {
+      MemberLocationUpdateReqDto reqDto =
+          MemberLocationUpdateReqDto.builder()
+              .lat(112.121)
+              .logt(121.121)
+              .build();
+
+      given(memberService.updateLocation(any(), any(), any())).willReturn(1L);
+
+      mockMvc.perform(put(MEMBER_URL + "/location/1")
+              .header(HttpHeaders.AUTHORIZATION, "JWT_TOKEN")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(reqDto)))
+          .andExpect(MockMvcResultMatchers.status().isCreated());
+    }
+
+    @Test
+    @DisplayName("접근 권한이 없을 때, 사용자 위치 정보 수정이 예외가 발생한다.")
+    void 접근_권한이_없을_때_사용자_위치_정보_수정이_예외가_발생한다() throws Exception {
+      MemberLocationUpdateReqDto reqDto =
+          MemberLocationUpdateReqDto.builder()
+              .lat(112.121)
+              .logt(121.121)
+              .build();
+
+      given(memberService.updateLocation(any(), any(), any())).willThrow(
+          new BusinessException(1, "memberId", ErrorCode.ACCESS_DENIED_EXCEPTION)
+      );
+
+      mockMvc.perform(put(MEMBER_URL + "/location/1")
+              .header(HttpHeaders.AUTHORIZATION, "JWT_TOKEN")
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(objectMapper.writeValueAsString(reqDto)))
+          .andExpect(MockMvcResultMatchers.status().isForbidden());
+    }
+  }
+}


### PR DESCRIPTION
## 🔥 Related Issue

close: #28 

## 📝 Description
사용자 정보 반환
- 주로 사용자의 위치를 가져올 때 사용하고, 자주 사용해야 하므로 Fetch Join을 통해 쿼리문을 최적화 하였습니다.
- JWT 인증만 있어도, 사용이 가능하게 하였습니다.

사용자 위치 업데이트
- 사용자 위치는 `Nullable` 이기 때문에, `PUT`으로 두어, 처음 생성되면 DB에 저장을 하고, 처음이 아니라면 DB에 수정을 하는 방식을 사용하였습니다.
- JWT 토큰이 가진 `account 명`과 동일하지 않으면, 사용할 수 없습니다.

## ⭐️ Review
JWT 에 관한 인증 테스트는 Controller 테스트와 따로 두어 진행해야할 것 같습니다.
