### PR TITLE
Feature/#29 평가 작성 및 조회 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -70,3 +70,4 @@
 ```
 
 include::member.adoc[]
+include::review.adoc[]

--- a/src/docs/asciidoc/review.adoc
+++ b/src/docs/asciidoc/review.adoc
@@ -1,0 +1,27 @@
+== 리뷰
+
+=== 리뷰 작성
+
+request
+
+include::{snippets}/write-review/정상적인_데이터_일_때_리뷰_작성에_성공한다/http-request.adoc[]
+
+response
+
+- 201
+include::{snippets}/write-review/정상적인_데이터_일_때_리뷰_작성에_성공한다/http-response.adoc[]
+
+- 400 (점수 형식 틀림)
+include::{snippets}/write-review/점수_형식이_맞지_않으면_리뷰_작성에_실패한다/http-response.adoc[]
+
+== 회사의 모든 리뷰 조회
+
+request
+
+include::{snippets}/read-review/정상적으로_회사의_모든_리뷰를_반환한다/http-request.adoc[]
+
+response
+
+- 200
+
+include::{snippets}/read-review/정상적으로_회사의_모든_리뷰를_반환한다/http-response.adoc[]

--- a/src/main/java/com/wanted/domain/auth/application/AuthService.java
+++ b/src/main/java/com/wanted/domain/auth/application/AuthService.java
@@ -156,4 +156,24 @@ public class AuthService {
     // 4. 저장소에서 회원 ID 를 기반으로 Refresh Token 삭제
     refreshTokenRepository.deleteByKey(authentication.getName());
   }
+
+  /**
+   * 토큰의 회원 account 와 ID 회원의 account가 같은지 확인
+   *
+   * @param token    확인할 토큰
+   * @param memberId 비교할 회원의 id
+   */
+  public void validSameTokenAccount(String token, Long memberId) {
+    // 회원의 아이디로 account 찾기
+    String memberAccount = memberRepository.findById(memberId).orElseThrow(
+        () -> new BusinessException(memberId, "memberId", ErrorCode.MEMBER_ACCOUNT_NOT_FOUND)
+    ).getAccount();
+
+    // 토큰으로 account 찾기
+    String tokenAccount = tokenProvider.getAccountFromToken(token);
+
+    if (!memberAccount.equals(tokenAccount)) {
+      throw new BusinessException(memberAccount, "account", ErrorCode.ACCESS_DENIED_EXCEPTION);
+    }
+  }
 }

--- a/src/main/java/com/wanted/domain/member/dto/request/MemberLocationUpdateReqDto.java
+++ b/src/main/java/com/wanted/domain/member/dto/request/MemberLocationUpdateReqDto.java
@@ -17,11 +17,11 @@ import lombok.NoArgsConstructor;
 public class MemberLocationUpdateReqDto {
 
   // 위도
-  @NotNull
+  @NotNull(message = "위도를 입력해주세요.")
   private Double lat;
 
   // 경도
-  @NotNull
+  @NotNull(message = "경도를 입력해주세요.")
   private Double logt;
 
   public MemberLocation toEntity() {

--- a/src/main/java/com/wanted/domain/restaurant/entity/Restaurant.java
+++ b/src/main/java/com/wanted/domain/restaurant/entity/Restaurant.java
@@ -74,10 +74,12 @@ public class Restaurant {
   private List<Review> reviews = new ArrayList<>();
 
   @Builder
-  private Restaurant(RestaurantEmployee restaurantEmployee, RestaurantFacility restaurantFacility,
+  private Restaurant(Long id, RestaurantEmployee restaurantEmployee,
+      RestaurantFacility restaurantFacility,
       RestaurantHygiene restaurantHygiene, RestaurantLocation restaurantLocation,
       RestaurantSite restaurantSite, RestaurantType restaurantType,
       RestaurantWorkplace restaurantWorkplace) {
+    this.id = id;
     this.restaurantEmployee = restaurantEmployee;
     this.restaurantFacility = restaurantFacility;
     this.restaurantHygiene = restaurantHygiene;

--- a/src/main/java/com/wanted/domain/restaurant/entity/Restaurant.java
+++ b/src/main/java/com/wanted/domain/restaurant/entity/Restaurant.java
@@ -1,5 +1,7 @@
 package com.wanted.domain.restaurant.entity;
 
+import static jakarta.persistence.CascadeType.ALL;
+
 import com.wanted.domain.restaurant.entity.employee.RestaurantEmployee;
 import com.wanted.domain.restaurant.entity.facility.RestaurantFacility;
 import com.wanted.domain.restaurant.entity.hygiene.RestaurantHygiene;
@@ -7,6 +9,7 @@ import com.wanted.domain.restaurant.entity.location.RestaurantLocation;
 import com.wanted.domain.restaurant.entity.site.RestaurantSite;
 import com.wanted.domain.restaurant.entity.type.RestaurantType;
 import com.wanted.domain.restaurant.entity.workplace.RestaurantWorkplace;
+import com.wanted.domain.review.entity.Review;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -14,7 +17,10 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -63,6 +69,10 @@ public class Restaurant {
   @Column(nullable = false)
   private double rate;
 
+  // 리뷰들 (1:N)
+  @OneToMany(mappedBy = "restaurant", cascade = ALL)
+  private List<Review> reviews = new ArrayList<>();
+
   @Builder
   private Restaurant(RestaurantEmployee restaurantEmployee, RestaurantFacility restaurantFacility,
       RestaurantHygiene restaurantHygiene, RestaurantLocation restaurantLocation,
@@ -75,5 +85,15 @@ public class Restaurant {
     this.restaurantSite = restaurantSite;
     this.restaurantType = restaurantType;
     this.restaurantWorkplace = restaurantWorkplace;
+  }
+
+  /**
+   * 평점을 업데이트 한다.
+   * 총 평점 (원래 총 평점(원래 평점 * 원래 리뷰의 수) + 새로운 평점) / 총 리뷰 수 (원래 리뷰의 수 + 1)
+   *
+   * @param score 새로 들어온 평점
+   */
+  public void updateRate(Double score) {
+    this.rate = (this.rate * reviews.size() + score) / (reviews.size() + 1);
   }
 }

--- a/src/main/java/com/wanted/domain/review/api/ReviewController.java
+++ b/src/main/java/com/wanted/domain/review/api/ReviewController.java
@@ -5,11 +5,13 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import com.wanted.domain.auth.application.AuthService;
 import com.wanted.domain.review.application.ReviewService;
 import com.wanted.domain.review.dto.request.ReviewWriteReqDto;
+import com.wanted.domain.review.dto.response.ReviewsInRestaurantResDto;
 import com.wanted.global.util.format.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -47,5 +49,21 @@ public class ReviewController {
 
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(ApiResponse.toSuccessForm(reviewId));
+  }
+
+  /**
+   * 식당의 모든 리뷰 조회
+   *
+   * @param restaurantId 식당 id
+   * @return 200, 식당의 모든 리뷰 데이터
+   */
+  @GetMapping("/restaurants/{restaurantId}")
+  public ResponseEntity<ApiResponse> readAllReviewsInRestaurant(
+      @PathVariable("restaurantId") Long restaurantId
+  ) {
+    ReviewsInRestaurantResDto resDto = reviewService.readAllReviewsInRestaurant(restaurantId);
+
+    return ResponseEntity.ok(
+        ApiResponse.toSuccessForm(resDto));
   }
 }

--- a/src/main/java/com/wanted/domain/review/api/ReviewController.java
+++ b/src/main/java/com/wanted/domain/review/api/ReviewController.java
@@ -1,0 +1,51 @@
+package com.wanted.domain.review.api;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+import com.wanted.domain.auth.application.AuthService;
+import com.wanted.domain.review.application.ReviewService;
+import com.wanted.domain.review.dto.request.ReviewWriteReqDto;
+import com.wanted.global.util.format.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/reviews")
+@RequiredArgsConstructor
+public class ReviewController {
+
+  private final ReviewService reviewService;
+  private final AuthService authService;
+
+  /**
+   * 리뷰 작성
+   *
+   * @param memberId     회원 Id
+   * @param restaurantId 식당 Id
+   * @param reqDto       리뷰 작성에 필요한 데이터 req dto
+   * @return 201, 작성된 리뷰 Id
+   */
+  @PostMapping("/members/{memberId}/{restaurantId}")
+  public ResponseEntity<ApiResponse> writeReview(
+      @RequestHeader(AUTHORIZATION) String token,
+      @PathVariable("memberId") Long memberId,
+      @PathVariable("restaurantId") Long restaurantId,
+      @Valid @RequestBody ReviewWriteReqDto reqDto
+  ) {
+    // 토큰의 유저 account 와 리뷰를 작성할 유저 account 는 같아야 한다.
+    authService.validSameTokenAccount(token, memberId);
+
+    Long reviewId = reviewService.writeReview(memberId, restaurantId, reqDto);
+
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(ApiResponse.toSuccessForm(reviewId));
+  }
+}

--- a/src/main/java/com/wanted/domain/review/application/ReviewService.java
+++ b/src/main/java/com/wanted/domain/review/application/ReviewService.java
@@ -1,0 +1,80 @@
+package com.wanted.domain.review.application;
+
+import com.wanted.domain.member.dao.MemberRepository;
+import com.wanted.domain.member.entity.Member;
+import com.wanted.domain.restaurant.dao.RestaurantRepository;
+import com.wanted.domain.restaurant.entity.Restaurant;
+import com.wanted.domain.review.dao.ReviewRepository;
+import com.wanted.domain.review.dto.request.ReviewWriteReqDto;
+import com.wanted.domain.review.entity.Review;
+import com.wanted.global.error.BusinessException;
+import com.wanted.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReviewService {
+
+  private final MemberRepository memberRepository;
+  private final ReviewRepository reviewRepository;
+  private final RestaurantRepository restaurantRepository;
+
+  /**
+   * 리뷰 작성
+   * 작성자는 해당 식당에 작성한 기록이 있으면 작성이 되면 안된다.
+   * 작성을 한 후, 식당의 평점 컬럼에 반영을 시켜야 한다.
+   *
+   * @param memberId     회원 Id
+   * @param restaurantId 식당 Id
+   * @param reqDto       리뷰 작성에 필요한 데이터 req dto
+   * @return 작성된 리뷰 Id
+   */
+  @Transactional
+  public Long writeReview(Long memberId, Long restaurantId, ReviewWriteReqDto reqDto) {
+
+    // id로 회원을 가져온다.
+    Member member = getMemberById(memberId);
+    // 회원이 리뷰를 쓸 자격이 있는지 확인
+    member.validCanWriteReview(restaurantId);
+
+    Restaurant restaurant = getRestaurantById(restaurantId);
+
+    // 가져온 Entity와 reqDto 바탕으로 Review Entity 생성 + 평점 반영
+    Review review = reqDto.toEntity(member, restaurant);
+    // 저장
+    Long reviewId = reviewRepository.save(review).getId();
+
+    return reviewId;
+  }
+
+  /**
+   * 회원 id로 회원 찾기.
+   * 없으면 404 예외 처리
+   *
+   * @param memberId 회원 id
+   * @return 찾은 회원 entity
+   */
+  private Member getMemberById(Long memberId) {
+    Member member = memberRepository.findById(memberId).orElseThrow(
+        () -> new BusinessException(memberId, "memberId", ErrorCode.MEMBER_NOT_FOUND)
+    );
+    return member;
+  }
+
+  /**
+   * 식당 id로 식당 찾기.
+   * 없으면 404 예외 처리
+   *
+   * @param restaurantId 식당 id
+   * @return 찾은 식당 entity
+   */
+  private Restaurant getRestaurantById(Long restaurantId) {
+    Restaurant restaurant = restaurantRepository.findById(restaurantId).orElseThrow(
+        () -> new BusinessException(restaurantId, "restaurantId", ErrorCode.RESTAURANT_NOT_FOUND)
+    );
+    return restaurant;
+  }
+}

--- a/src/main/java/com/wanted/domain/review/application/ReviewService.java
+++ b/src/main/java/com/wanted/domain/review/application/ReviewService.java
@@ -6,9 +6,11 @@ import com.wanted.domain.restaurant.dao.RestaurantRepository;
 import com.wanted.domain.restaurant.entity.Restaurant;
 import com.wanted.domain.review.dao.ReviewRepository;
 import com.wanted.domain.review.dto.request.ReviewWriteReqDto;
+import com.wanted.domain.review.dto.response.ReviewsInRestaurantResDto;
 import com.wanted.domain.review.entity.Review;
 import com.wanted.global.error.BusinessException;
 import com.wanted.global.error.ErrorCode;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -76,5 +78,17 @@ public class ReviewService {
         () -> new BusinessException(restaurantId, "restaurantId", ErrorCode.RESTAURANT_NOT_FOUND)
     );
     return restaurant;
+  }
+
+  /**
+   * 식당의 모든 리뷰 조회
+   *
+   * @param restaurantId 식당 id
+   * @return 식당의 모든 리뷰 데이터
+   */
+  public ReviewsInRestaurantResDto readAllReviewsInRestaurant(Long restaurantId) {
+    List<Review> reviews = getRestaurantById(restaurantId).getReviews();
+
+    return new ReviewsInRestaurantResDto(reviews);
   }
 }

--- a/src/main/java/com/wanted/domain/review/dao/ReviewRepository.java
+++ b/src/main/java/com/wanted/domain/review/dao/ReviewRepository.java
@@ -1,0 +1,8 @@
+package com.wanted.domain.review.dao;
+
+import com.wanted.domain.review.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+}

--- a/src/main/java/com/wanted/domain/review/dto/request/ReviewWriteReqDto.java
+++ b/src/main/java/com/wanted/domain/review/dto/request/ReviewWriteReqDto.java
@@ -1,0 +1,48 @@
+package com.wanted.domain.review.dto.request;
+
+import com.wanted.domain.member.entity.Member;
+import com.wanted.domain.restaurant.entity.Restaurant;
+import com.wanted.domain.review.entity.Review;
+import com.wanted.global.annotation.valid.review.ValidScoreValue;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 리뷰를 작성할 때 데이터를 받는 req Dto
+ */
+@Getter
+@RequiredArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReviewWriteReqDto {
+
+  // 점수
+  @ValidScoreValue(message = "1.0에서 5.0 사이인 0.5 단위의 점수를 입력해주세요")
+  private Double score;
+
+  // 내용
+  @NotEmpty(message = "리뷰의 내용을 작성해주세요.")
+  private String content;
+
+  /**
+   * 엔티티로 생성
+   * 식당의 평점도 반영
+   *
+   * @param member     작성자
+   * @param restaurant 리뷰 대상 식당
+   * @return 리뷰 Entity
+   */
+  public Review toEntity(Member member, Restaurant restaurant) {
+    restaurant.updateRate(this.score);
+
+    return Review.builder()
+        .member(member)
+        .restaurant(restaurant)
+        .content(this.content)
+        .score(this.score)
+        .build();
+  }
+}

--- a/src/main/java/com/wanted/domain/review/dto/response/ReviewResDto.java
+++ b/src/main/java/com/wanted/domain/review/dto/response/ReviewResDto.java
@@ -1,0 +1,30 @@
+package com.wanted.domain.review.dto.response;
+
+import com.wanted.domain.review.entity.Review;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReviewResDto {
+
+  // 리뷰 아이디
+  private Long reviewId;
+  // 평점
+  private Double score;
+  // 내용
+  private String content;
+  // 작성자 계정 id
+  private String userAccount;
+
+  public ReviewResDto(Review review) {
+    this.reviewId = review.getId();
+    this.score = review.getScore();
+    this.content = review.getContent();
+    this.userAccount = review.getMember().getAccount();
+  }
+}

--- a/src/main/java/com/wanted/domain/review/dto/response/ReviewsInRestaurantResDto.java
+++ b/src/main/java/com/wanted/domain/review/dto/response/ReviewsInRestaurantResDto.java
@@ -1,0 +1,21 @@
+package com.wanted.domain.review.dto.response;
+
+import com.wanted.domain.review.entity.Review;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ReviewsInRestaurantResDto {
+
+  private List<ReviewResDto> reviews = new ArrayList<>();
+
+  public ReviewsInRestaurantResDto(List<Review> reviews) {
+    this.reviews = reviews.stream()
+        .map(ReviewResDto::new)
+        .collect(Collectors.toList());
+  }
+}

--- a/src/main/java/com/wanted/domain/review/entity/Review.java
+++ b/src/main/java/com/wanted/domain/review/entity/Review.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -46,4 +47,13 @@ public class Review extends BaseTimeEntity {
   // 내용
   @Column(name = "content", nullable = false)
   private String content;
+
+  @Builder
+  public Review(Long id, Member member, Restaurant restaurant, Double score, String content) {
+    this.id = id;
+    this.member = member;
+    this.restaurant = restaurant;
+    this.score = score;
+    this.content = content;
+  }
 }

--- a/src/main/java/com/wanted/domain/review/entity/Review.java
+++ b/src/main/java/com/wanted/domain/review/entity/Review.java
@@ -1,0 +1,49 @@
+package com.wanted.domain.review.entity;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import com.wanted.domain.member.entity.Member;
+import com.wanted.domain.restaurant.entity.Restaurant;
+import com.wanted.global.config.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Getter
+@Table(name = "review")
+public class Review extends BaseTimeEntity {
+
+  // 리뷰 Id
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  @Column(name = "review_id", nullable = false)
+  private Long id;
+
+  // 작성자 (N:1)
+  @ManyToOne(fetch = LAZY)
+  @JoinColumn(name = "member_id", nullable = false)
+  private Member member;
+
+  // 리뷰 대상 음식점 (N:1)
+  @ManyToOne(fetch = LAZY)
+  @JoinColumn(name = "restaurant_id", nullable = false)
+  private Restaurant restaurant;
+
+  // 점수
+  @Column(name = "score", nullable = false)
+  private Double score;
+
+  // 내용
+  @Column(name = "content", nullable = false)
+  private String content;
+}

--- a/src/main/java/com/wanted/global/annotation/valid/review/ScoreValueValidator.java
+++ b/src/main/java/com/wanted/global/annotation/valid/review/ScoreValueValidator.java
@@ -1,0 +1,22 @@
+package com.wanted.global.annotation.valid.review;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+/**
+ * 커스텀 Validator
+ * 스코어가 1.0 1.5... 5.0 까지 0.5 단위로 1~5 사이로 오는지 검증
+ */
+public class ScoreValueValidator implements ConstraintValidator<ValidScoreValue, Double> {
+
+  @Override
+  public void initialize(ValidScoreValue constraintAnnotation) {
+  }
+
+  @Override
+  public boolean isValid(Double value, ConstraintValidatorContext context) {
+
+    return value == 1.0 || value == 1.5 || value == 2.0 || value == 2.5 || value == 3.0 ||
+        value == 3.5 || value == 4.0 || value == 4.5 || value == 5.0;
+  }
+}

--- a/src/main/java/com/wanted/global/annotation/valid/review/ValidScoreValue.java
+++ b/src/main/java/com/wanted/global/annotation/valid/review/ValidScoreValue.java
@@ -1,0 +1,24 @@
+package com.wanted.global.annotation.valid.review;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 커스텀 Validator 어노테이션
+ * 스코어가 1.0 1.5... 5.0 까지 0.5 단위로 1~5 사이로 오는지 검증
+ */
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ScoreValueValidator.class)
+public @interface ValidScoreValue {
+
+  String message() default "ScoreValidFail";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/wanted/global/error/ErrorCode.java
+++ b/src/main/java/com/wanted/global/error/ErrorCode.java
@@ -20,7 +20,14 @@ public enum ErrorCode {
   MEMBER_ACCOUNT_DUPLICATE("중복된 아이디 입니다.", HttpStatus.BAD_REQUEST),
   MEMBER_ACCOUNT_NOT_FOUND("아이디를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
   MEMBER_PASSWORD_BAD_REQUEST("비밀번호가 틀렸습니다.", HttpStatus.BAD_REQUEST),
-  MEMBER_NOT_FOUND("존재하지 않은 회원입니다", HttpStatus.BAD_REQUEST),
+  MEMBER_NOT_FOUND("존재하지 않은 회원입니다", HttpStatus.NOT_FOUND),
+
+  // Restaurant
+  RESTAURANT_NOT_FOUND("존재하지 않은 가게입니다.", HttpStatus.NOT_FOUND),
+
+  // Review
+  REVIEW_SCORE_BAD_REQUEST("점수 양식이 잘못되었습니다,", HttpStatus.BAD_REQUEST),
+  REVIEW_DUPLICATE_WRITE("이미 작성한 리뷰가 있습니다", HttpStatus.BAD_REQUEST),
 
   // Security
   ACCESS_DENIED_EXCEPTION("필요한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN),

--- a/src/main/java/com/wanted/global/error/ExceptionAdvice.java
+++ b/src/main/java/com/wanted/global/error/ExceptionAdvice.java
@@ -54,7 +54,7 @@ public class ExceptionAdvice {
     return bindingResult.getFieldErrors().stream()
         .map(fieldError ->
             getErrorMessage(
-                (String) fieldError.getRejectedValue(),
+                String.valueOf(fieldError.getRejectedValue()), // (String)은 Double 등이 올 경우 에러
                 fieldError.getField(),
                 fieldError.getDefaultMessage()
             )

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,10 @@ spring:
     hibernate:
       ddl-auto: update
 
+    properties:
+      hibernate:
+        jdbc:
+          batch_size: 1000
 #p6spy
 decorator:
   datasource:

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -461,6 +461,12 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_로그아웃">로그아웃</a></li>
 <li><a href="#_사용자_정보_조회">사용자 정보 조회</a></li>
 <li><a href="#_사용자_위치_정보_수정">사용자 위치 정보 수정</a></li>
+<li><a href="#_리뷰">리뷰</a>
+<ul class="sectlevel2">
+<li><a href="#_리뷰_작성">리뷰 작성</a></li>
+</ul>
+</li>
+<li><a href="#_회사의_모든_리뷰_조회">회사의 모든 리뷰 조회</a></li>
 </ul>
 </li>
 </ul>
@@ -937,11 +943,133 @@ Content-Length: 117
 </div>
 </div>
 </div>
+<div class="sect1">
+<h2 id="_리뷰">리뷰</h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_리뷰_작성">리뷰 작성</h3>
+<div class="paragraph">
+<p>request</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/reviews/members/1/1 HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: JWT_TOKEN
+Content-Length: 53
+Host: localhost:8080
+
+{
+  "score" : 4.5,
+  "content" : "리뷰 내용"
+}</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>response</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>201</p>
+</li>
+</ul>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>HTTP/1.1 201 Created
+Content-Type: application/json;charset=UTF-8
+Content-Length: 64
+
+{
+  "status" : "success",
+  "message" : null,
+  "data" : 1
+}</pre>
+</div>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>400 (점수 형식 틀림)</p>
+</li>
+</ul>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>HTTP/1.1 400 Bad Request
+Content-Type: application/json;charset=UTF-8
+Content-Length: 142
+
+{
+  "status" : "error",
+  "message" : "[4.3] score: 1.0에서 5.0 사이인 0.5 단위의 점수를 입력해주세요",
+  "data" : null
+}</pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_회사의_모든_리뷰_조회">회사의 모든 리뷰 조회</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>request</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/reviews/restaurants/1 HTTP/1.1
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>response</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>200</p>
+</li>
+</ul>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+Content-Length: 464
+
+{
+  "status" : "success",
+  "message" : null,
+  "data" : {
+    "reviews" : [ {
+      "reviewId" : 1,
+      "score" : 4.5,
+      "content" : "리뷰 내용",
+      "userAccount" : "test1234"
+    }, {
+      "reviewId" : 2,
+      "score" : 4.5,
+      "content" : "리뷰 내용",
+      "userAccount" : "test1234"
+    }, {
+      "reviewId" : 3,
+      "score" : 4.5,
+      "content" : "리뷰 내용",
+      "userAccount" : "test1234"
+    } ]
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-11-03 23:43:35 +0900
+Last updated 2023-11-07 23:58:32 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/src/test/java/com/wanted/domain/review/ReviewTestHelper.java
+++ b/src/test/java/com/wanted/domain/review/ReviewTestHelper.java
@@ -1,0 +1,18 @@
+package com.wanted.domain.review;
+
+import com.wanted.domain.member.MemberTestHelper;
+import com.wanted.domain.restaurant.entity.Restaurant;
+import com.wanted.domain.review.entity.Review;
+
+public class ReviewTestHelper {
+
+  public static Review createReview() {
+    return Review.builder()
+        .score(4.5)
+        .content("리뷰 내용")
+        .restaurant(Restaurant.builder().id(1L).build()) //TODO RestaurantTestHelper 추가
+        .member(MemberTestHelper.createMember())
+        .build();
+  }
+
+}

--- a/src/test/java/com/wanted/domain/review/ReviewTestHelper.java
+++ b/src/test/java/com/wanted/domain/review/ReviewTestHelper.java
@@ -6,8 +6,9 @@ import com.wanted.domain.review.entity.Review;
 
 public class ReviewTestHelper {
 
-  public static Review createReview() {
+  public static Review createReviewWithId(Long reviewId) {
     return Review.builder()
+        .id(reviewId)
         .score(4.5)
         .content("리뷰 내용")
         .restaurant(Restaurant.builder().id(1L).build()) //TODO RestaurantTestHelper 추가

--- a/src/test/java/com/wanted/domain/review/api/ReviewControllerTest.java
+++ b/src/test/java/com/wanted/domain/review/api/ReviewControllerTest.java
@@ -86,8 +86,8 @@ class ReviewControllerTest extends AbstractRestDocsTests {
     @DisplayName("정상적으로 회사의 모든 리뷰를 반환한다.")
     void 정상적으로_회사의_모든_리뷰를_반환한다() throws Exception {
       List<Review> reviews = new ArrayList<>();
-      for (int i = 0; i < 5; i++) {
-        reviews.add(ReviewTestHelper.createReview());
+      for (int i = 1; i <= 3; i++) {
+        reviews.add(ReviewTestHelper.createReviewWithId((long) i));
       }
       ReviewsInRestaurantResDto resDto = new ReviewsInRestaurantResDto(reviews);
 

--- a/src/test/java/com/wanted/domain/review/api/ReviewControllerTest.java
+++ b/src/test/java/com/wanted/domain/review/api/ReviewControllerTest.java
@@ -1,0 +1,100 @@
+package com.wanted.domain.review.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wanted.config.restdocs.AbstractRestDocsTests;
+import com.wanted.domain.auth.application.AuthService;
+import com.wanted.domain.review.ReviewTestHelper;
+import com.wanted.domain.review.application.ReviewService;
+import com.wanted.domain.review.dto.request.ReviewWriteReqDto;
+import com.wanted.domain.review.dto.response.ReviewsInRestaurantResDto;
+import com.wanted.domain.review.entity.Review;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+@WebMvcTest(controllers = ReviewController.class)
+class ReviewControllerTest extends AbstractRestDocsTests {
+
+  private final static String REVIEW_URL = "/api/v1/reviews";
+
+  @MockBean
+  private ReviewService reviewService;
+  @MockBean
+  private AuthService authService;
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Nested
+  @DisplayName("리뷰 작성 관련 테스트")
+  class WriteReview {
+
+    @Test
+    @DisplayName("정상적인 데이터 일 때, 리뷰 작성에 성공한다.")
+    void 정상적인_데이터_일_때_리뷰_작성에_성공한다() throws Exception {
+      ReviewWriteReqDto reqDto =
+          ReviewWriteReqDto.builder()
+              .content("리뷰 내용")
+              .score(4.5)
+              .build();
+
+      given(reviewService.writeReview(any(), any(), any())).willReturn(1L);
+
+      mockMvc.perform(post(REVIEW_URL + "/members/1/1")
+              .contentType(MediaType.APPLICATION_JSON)
+              .header(HttpHeaders.AUTHORIZATION, "JWT_TOKEN")
+              .content(objectMapper.writeValueAsString(reqDto)))
+          .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("점수 형식이 맞지 않으면, 리뷰 작성에 실패한다.")
+    void 점수_형식이_맞지_않으면_리뷰_작성에_실패한다() throws Exception {
+      ReviewWriteReqDto reqDto =
+          ReviewWriteReqDto.builder()
+              .content("리뷰 내용")
+              .score(4.3) // 잘못된 점수
+              .build();
+
+      given(reviewService.writeReview(any(), any(), any())).willReturn(1L);
+
+      mockMvc.perform(post(REVIEW_URL + "/members/1/1")
+              .contentType(MediaType.APPLICATION_JSON)
+              .header(HttpHeaders.AUTHORIZATION, "JWT_TOKEN")
+              .content(objectMapper.writeValueAsString(reqDto)))
+          .andExpect(status().isBadRequest());
+    }
+  }
+
+  @Nested
+  @DisplayName("리뷰 조회 관련 테스트")
+  class readReview {
+
+    @Test
+    @DisplayName("정상적으로 회사의 모든 리뷰를 반환한다.")
+    void 정상적으로_회사의_모든_리뷰를_반환한다() throws Exception {
+      List<Review> reviews = new ArrayList<>();
+      for (int i = 0; i < 5; i++) {
+        reviews.add(ReviewTestHelper.createReview());
+      }
+      ReviewsInRestaurantResDto resDto = new ReviewsInRestaurantResDto(reviews);
+
+      given(reviewService.readAllReviewsInRestaurant(1L)).willReturn(resDto);
+
+      mockMvc.perform(get(REVIEW_URL + "/restaurants/1"))
+          .andExpect(status().isOk());
+    }
+  }
+}


### PR DESCRIPTION
## 🔥 Related Issue

close: #29 #32 

## 📝 Description
평가 기능을 구현하는데, CRUD가 모두 필요할 것 같아 범위를 확장하였습니다.

평가 작성할 때, 점수는 1.0 1.5 이런식으로 1~5점 사이 0.5점 단위로만 가능하게 하였으며,
JWT토큰으로 자신이 작성하는게 맞는지 확인하였습니다.

또한 식당의 평균 점수인 `rate`에 반영을 하였습니다.
`rate = 총 평점 (원래 총 평점(원래 평점 * 원래 리뷰의 수) + 새로운 평점) / 총 리뷰 수 (원래 리뷰의 수 + 1)`


평가를 조회할 때, 여러 조회 기능이 필요가 예상가지만, 식당의 모든 평가를 조회하는 기능을 구현하였습니다.

## ⭐️ Review
URL에 관하서 얘기하면 좋을 것 같아요!

작성
`post - /members/{memberId}/{restaurantId}`
근거 - 추후 `get,put,path - /members/{memberId}/{restaurantId} ` 를 사용하므로써 Restful 함

식당의 모든 리뷰 조회
`get - /restaurants/{restaurantId}`
근거 - 그냥 `/{restaurantId}`을 하기엔 `/{reviewsId}`가 있기 때문